### PR TITLE
add alwaysAppend for more consistent filenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,9 @@ function findIncrementalUniqueFilename(file, options, callback) {
   var filename;
   var append = '';
 
+  if(options.alwaysAppend && !file.increment)
+    file.increment = 1;
+
   if (file.increment) {
     if(options.mode == 'numeric') {
       append = '' + file.increment;
@@ -63,8 +66,8 @@ function findIncrementalUniqueFilename(file, options, callback) {
     else {
       append = str.numberToString(file.increment, options.charset);
     }
-    
-    
+
+
 
     if(options.paddingSize) {
       while(append.length < options.paddingSize) {

--- a/test/main.js
+++ b/test/main.js
@@ -236,6 +236,17 @@ describe('Get non existing file path', function() {
       done();
     });
   });
+
+  it('should return the first non-existing file path - with separator and attachment', function (done) {
+    fs.exists.withArgs('/path/to/dir/file-1.jpg').yields(false);
+
+    uniquefilename.get('/path/to/dir/file.jpg', {alwaysAppend: true},
+      function(filename) {
+
+      assert.equal(filename, '/path/to/dir/file-1.jpg');
+      done();
+    });
+  });
 });
 
 


### PR DESCRIPTION
Addresses #1 ensuring output filenames always maintain the same structure.

```
file-1.jpg
file-2.jpg
file-3.jpg
```
vs
```
file.jpg
file-2.jpg
file-3.jpg
```